### PR TITLE
Custom field and tmp dir fix

### DIFF
--- a/lib/RainGauge.php
+++ b/lib/RainGauge.php
@@ -211,7 +211,7 @@ class RainGauge {
             }
             else if ($file_type == 'stacktrace')
             {
-                $data['file_data'] = htmlspecialchars($this->model->pmp_summary($data['sample'],$data['file']));
+                $data['file_data'] = htmlspecialchars($this->model->pmp_summary($data['sample'],$data['file'], $data['server']));
                 $data['file_data'] .= "<br/><hr>";
             }
             else if ($file_type == 'mutex-status2')

--- a/lib/RainGauge.php
+++ b/lib/RainGauge.php
@@ -230,7 +230,11 @@ class RainGauge {
                 $data['file_data'] .= join("\n", array_map(function ($x,$y) { return "$x = $y"; } , array_keys($mutexes), array_values($mutexes)));
                 $data['file_data'] .= "<hr>";
             }
-        } else {
+        }
+        else if ($file_type == 'custom-plaintext') {
+                $data['file_data'] = $data['file'];
+	    }
+        else {
             $data['file_lines'] = $this->model->sift($data['server'], $data['sample'], get_var('sift'));
         }
         $data['percent'] = $this->model->get_sample_percent($data['server'], $data['sample']);


### PR DESCRIPTION
Pull request contains:
1. Add new type for files (custom-plaintext) to attach plaintext files to archive and display them without any parsing
2. Fix for tmp_dir function, which was broken if there was two files with the same date.
