### PR TITLE
Don't include saved_trigger_values in the file list

### DIFF
--- a/lib/RainGaugeModel.php
+++ b/lib/RainGaugeModel.php
@@ -112,7 +112,7 @@ class RainGaugeModel {
         $result = array();
         $DIR = opendir($tmp_dir);
         while ($file = readdir($DIR)) {
-            if (in_array($file, array('.', '..'))) {
+            if (in_array($file, array('.', '..', 'saved_trigger_values'))) {
                 continue;
             }
             $result[] = array('name' => $file,


### PR DESCRIPTION
This file isn't parsed properly because it doesn't have the date prefix (and isn't useful)